### PR TITLE
feat: enable CORS and update API URLs for kontext domain

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,7 +9,7 @@ import LoraModal from './components/LoraModal';
 import ImageModal from './components/ImageModal';
 import ControlBar from './components/ControlBar';
 
-const API = import.meta.env.VITE_API_URL || '';
+const API = import.meta.env.VITE_API_URL || 'https://kontext.gosystem.io/api';
 
 export default function App() {
   const [boards, setBoards] = useState([]);
@@ -42,16 +42,16 @@ export default function App() {
   };
 
   useEffect(() => {
-    axios.get(`${API}/api/loras`).then((r) => setLoraList(r.data));
+    axios.get(`${API}/loras`).then((r) => setLoraList(r.data));
     (async () => {
-      const { data: boards } = await axios.get(`${API}/api/boards`);
+      const { data: boards } = await axios.get(`${API}/boards`);
       setBoards(boards);
       if (boards.length) setBid(boards[boards.length - 1].id);
       const cacheObj = {};
       const thumbsObj = {};
       await Promise.all(
         boards.map(async (b) => {
-          const { data: imgs } = await axios.get(`${API}/api/boards/${b.id}`);
+          const { data: imgs } = await axios.get(`${API}/boards/${b.id}`);
           cacheObj[b.id] = imgs;
           cacheImages(imgs);
           const last = imgs.at(-1)?.url;
@@ -72,7 +72,7 @@ export default function App() {
         setThumbs((t) => ({ ...t, [bid]: cached[cached.length - 1].url }));
       return;
     }
-    axios.get(`${API}/api/boards/${bid}`).then((r) => {
+    axios.get(`${API}/boards/${bid}`).then((r) => {
       setGal(r.data);
       setCache((c) => ({ ...c, [bid]: r.data }));
       if (r.data.length)
@@ -117,14 +117,13 @@ export default function App() {
     setErr('');
 
     try {
-      const fd = new FormData();
       file ? fd.append('image', file) : fd.append('image_url', preview);
       fd.append('prompt', prompt);
       if (pick?.url) fd.append('lora_path', pick.url);
       if (pick?.name) fd.append('lora_name', pick.name);
 
       const { data } = await axios.post(
-        `${API}/api/boards/${bid}/generate`,
+        `${API}/boards/${bid}/generate`,
         fd
       );
 
@@ -149,7 +148,7 @@ export default function App() {
   };
 
   const newBoard = async () => {
-    const { data } = await axios.post(`${API}/api/boards`);
+    const { data } = await axios.post(`${API}/boards`);
     setBoards([...boards, data]);
     setBid(data.id);
     setGal([]);
@@ -165,7 +164,7 @@ export default function App() {
         onNew={newBoard}
         onPick={setBid}
         onDelete={async (id) => {
-          await axios.delete(`${API}/api/boards/${id}`);
+          await axios.delete(`${API}/boards/${id}`);
           setBoards(boards.filter((b) => b.id !== id));
           setCache((c) => {
             const { [id]: _, ...rest } = c;

--- a/client/src/components/ImageCard.jsx
+++ b/client/src/components/ImageCard.jsx
@@ -2,7 +2,7 @@
 import axios from 'axios';
 import { Download, Trash2 } from 'lucide-react';
 
-const API = import.meta.env.VITE_API_URL || '';
+const API = import.meta.env.VITE_API_URL || 'https://kontext.gosystem.io/api';
 
 export default function ImageCard({ img, boardId, onRemove, onShow }) {
   const save = async () => {
@@ -17,7 +17,7 @@ export default function ImageCard({ img, boardId, onRemove, onShow }) {
   };
 
   const del = async () => {
-    await axios.delete(`${API}/api/boards/${boardId}/images/${img.id}`);
+    await axios.delete(`${API}/boards/${boardId}/images/${img.id}`);
     onRemove(img.id);
   };
 

--- a/client/src/components/LoraModal.jsx
+++ b/client/src/components/LoraModal.jsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { Plus, X, Pencil, Trash2 } from 'lucide-react';
 import Compare from './Compare';
 
-const API = import.meta.env.VITE_API_URL || '';
+const API = import.meta.env.VITE_API_URL || 'https://kontext.gosystem.io/api';
 
 export default function LoraModal({
   open,
@@ -37,7 +37,7 @@ export default function LoraModal({
 
   const handleDelete = async (id) => {
     if (!window.confirm('Удалить эту LoRA?')) return;
-    await axios.delete(`${API}/api/loras/${id}`);
+    await axios.delete(`${API}/loras/${id}`);
     onDelete(id);
     if (editId === id) reset();
   };
@@ -52,10 +52,10 @@ export default function LoraModal({
     Object.entries(files).forEach(([k, v]) => v && fd.append(k, v));
 
     if (editId > 0) {
-      await axios.put(`${API}/api/loras/${editId}`, fd);
+      await axios.put(`${API}/loras/${editId}`, fd);
       onUpdate(editId, f);
     } else {
-      const { data } = await axios.post(`${API}/api/loras`, fd);
+      const { data } = await axios.post(`${API}/loras`, fd);
       onAdd(data);
     }
     reset();

--- a/server/index.js
+++ b/server/index.js
@@ -50,7 +50,22 @@ const withLock = async (key, fn) => {
 
 /* ---------- express ---------- */
 const app = express();
-app.use(cors());
+
+const allowedOrigins = [
+  'https://kontext.gosystem.io',
+  'http://localhost:5173'
+];
+
+const corsOptions = {
+  origin: (origin, cb) => {
+    if (!origin || allowedOrigins.includes(origin)) cb(null, true);
+    else cb(new Error('Not allowed by CORS'));
+  },
+  credentials: true
+};
+
+app.use(cors(corsOptions));
+app.options('*', cors(corsOptions));
 app.use(express.json({ limit: '5mb' }));
 const upload = multer({ storage: multer.memoryStorage() });
 
@@ -232,7 +247,9 @@ if (fssync.existsSync(dist)) {
 }
 
 /* ---------- запускаем ---------- */
-const server = app.listen(4000, () =>
-  console.log('API & UI ⇒ http://localhost:4000')
+const PORT = process.env.PORT || 4000;
+const HOST = '0.0.0.0';
+const server = app.listen(PORT, HOST, () =>
+  console.log(`API & UI ⇒ http://${HOST}:${PORT}`)
 );
 server.setTimeout(240_000); // 4 минуты на любой запрос


### PR DESCRIPTION
## Summary
- allow https://kontext.gosystem.io and localhost:5173 through CORS and handle preflight requests
- listen on all interfaces for external access
- point frontend API calls to https://kontext.gosystem.io/api

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894f20747c4832c84bb7db1c607ac32