### PR TITLE
Serve UI and API from a single port

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -11,5 +11,10 @@ export default defineConfig({
       '127.0.0.1',
       'kontext.gosystem.io'
     ]
+  },
+  // Build React app into client/dist so Express can serve it
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true
   }
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "install-all": "npm --prefix server install && npm --prefix client install",
     "dev": "concurrently \"npm --prefix server run dev\" \"npm --prefix client run dev -- --host\"",
     "build": "npm --prefix client run build",
-    "serve": "npm --prefix server run serve"
+    "serve": "npm --prefix server run serve",
+    "start": "npm run build && npm run serve"
   },
   "devDependencies": {
     "concurrently": "^8.2.2"

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,6 @@ import fssync from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import express from 'express';
-import cors from 'cors';
 import multer from 'multer';
 import { fal } from '@fal-ai/client';
 import { Blob } from 'buffer';
@@ -50,7 +49,7 @@ const withLock = async (key, fn) => {
 
 /* ---------- express ---------- */
 const app = express();
-app.use(cors());
+// API and UI are served from the same origin, so no CORS middleware is needed
 app.use(express.json({ limit: '5mb' }));
 const upload = multer({ storage: multer.memoryStorage() });
 
@@ -226,7 +225,8 @@ const dist = path.join(__dirname, '..', 'client', 'dist');
 
 if (fssync.existsSync(dist)) {
   app.use(express.static(dist));
-  app.get('*', (_, res) => res.sendFile('index.html', { root: dist }));
+  // Serve index.html for all non-API routes to enable client-side routing
+  app.get(/^\/(?!api).*/, (_, res) => res.sendFile('index.html', { root: dist }));
 } else {
   console.warn('⚠️  client/dist не найден — сначала выполните `npm run build` в папке client');
 }


### PR DESCRIPTION
## Summary
- Serve built frontend assets and API routes from the same Express instance
- Build React app into `client/dist` so the server can serve it
- Add `npm start` script to build and launch the unified server

## Testing
- `npm run build`
- `FAL_KEY=1 node server/index.js`

------
https://chatgpt.com/codex/tasks/task_e_6894f490b61c832ca7c6fcd38a162578