### PR TITLE
Add debug logging and API status checks

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+DEBUG=true
+VITE_DEBUG=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+client/node_modules/
+server/node_modules/

--- a/client/.env
+++ b/client/.env
@@ -1,0 +1,1 @@
+VITE_DEBUG=true

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,0 +1,42 @@
+import axios from 'axios';
+
+export const API_BASE = import.meta.env.VITE_API_URL || 'https://kontext.gosystem.io/api';
+const DEBUG = import.meta.env.VITE_DEBUG === 'true';
+
+const api = axios.create({ baseURL: API_BASE });
+
+api.interceptors.request.use((config) => {
+  if (DEBUG) {
+    console.log('[API Request]', config.method?.toUpperCase(), config.baseURL + config.url, config.data || '');
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => {
+    if (DEBUG) {
+      console.log('[API Response]', response.status, response.config.baseURL + response.config.url, response.data);
+    }
+    return response;
+  },
+  (error) => {
+    if (DEBUG) {
+      console.error('[API Error]', error.config?.method?.toUpperCase(), (error.config?.baseURL || '') + (error.config?.url || ''), error.message);
+      if (error.response) console.error('Response data:', error.response.data);
+    }
+    return Promise.reject(error);
+  }
+);
+
+export const checkApiStatus = async () => {
+  try {
+    const res = await api.get('/status');
+    if (DEBUG) console.log('[API Status]', res.data);
+    return res.data;
+  } catch (err) {
+    if (DEBUG) console.error('[API Status Error]', err);
+    throw err;
+  }
+};
+
+export default api;

--- a/client/src/components/ImageCard.jsx
+++ b/client/src/components/ImageCard.jsx
@@ -1,8 +1,6 @@
 /* client/src/components/ImageCard.jsx */
-import axios from 'axios';
+import api from '../api';
 import { Download, Trash2 } from 'lucide-react';
-
-const API = import.meta.env.VITE_API_URL || 'https://kontext.gosystem.io/api';
 
 export default function ImageCard({ img, boardId, onRemove, onShow }) {
   const save = async () => {
@@ -17,8 +15,12 @@ export default function ImageCard({ img, boardId, onRemove, onShow }) {
   };
 
   const del = async () => {
-    await axios.delete(`${API}/boards/${boardId}/images/${img.id}`);
-    onRemove(img.id);
+    try {
+      await api.delete(`/boards/${boardId}/images/${img.id}`);
+      onRemove(img.id);
+    } catch (e) {
+      console.error('Failed to delete image', e);
+    }
   };
 
   return (

--- a/client/src/components/LoraModal.jsx
+++ b/client/src/components/LoraModal.jsx
@@ -1,10 +1,8 @@
 /* client/src/components/LoraModal.jsx */
 import { useState, useEffect } from 'react';
-import axios from 'axios';
+import api from '../api';
 import { Plus, X, Pencil, Trash2 } from 'lucide-react';
 import Compare from './Compare';
-
-const API = import.meta.env.VITE_API_URL || 'https://kontext.gosystem.io/api';
 
 export default function LoraModal({
   open,
@@ -37,7 +35,12 @@ export default function LoraModal({
 
   const handleDelete = async (id) => {
     if (!window.confirm('Удалить эту LoRA?')) return;
-    await axios.delete(`${API}/loras/${id}`);
+    try {
+      await api.delete(`/loras/${id}`);
+    } catch (e) {
+      console.error('Failed to delete lora', e);
+      return;
+    }
     onDelete(id);
     if (editId === id) reset();
   };
@@ -52,10 +55,10 @@ export default function LoraModal({
     Object.entries(files).forEach(([k, v]) => v && fd.append(k, v));
 
     if (editId > 0) {
-      await axios.put(`${API}/loras/${editId}`, fd);
+      await api.put(`/loras/${editId}`, fd);
       onUpdate(editId, f);
     } else {
-      const { data } = await axios.post(`${API}/loras`, fd);
+      const { data } = await api.post('/loras', fd);
       onAdd(data);
     }
     reset();


### PR DESCRIPTION
## Summary
- log requests and responses on the server with DEBUG flag and error middleware
- add API status endpoint and expose logging toggle via .env
- centralize frontend API calls with debug interceptors and status check

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix client test` *(fails: Missing script: "test")*
- `npm --prefix server test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894fc0b95b4832ca5c078768a9b936a